### PR TITLE
 Add support to load aggregate state until version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": "^7.2",
     "roave/security-advisories": "dev-master",
     "event-engine/php-document-store": "^0.2",
-    "event-engine/php-event-store": "^0.1",
+    "event-engine/php-event-store": "^0.2",
     "event-engine/php-messaging": "^0.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "php": "^7.2",
     "roave/security-advisories": "dev-master",
     "event-engine/php-document-store": "^0.2",
-    "event-engine/php-event-store": "^0.1"
+    "event-engine/php-event-store": "^0.1",
+    "event-engine/php-messaging": "^0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",

--- a/src/AggregateStateStore.php
+++ b/src/AggregateStateStore.php
@@ -23,4 +23,12 @@ interface AggregateStateStore
      * @throws AggregateNotFound
      */
     public function loadAggregateState(string $aggregateType, string $aggregateId, int $expectedVersion = null);
+
+    /**
+     * @param string $aggregateType
+     * @param string $aggregateId
+     * @param int $maxVersion
+     * @return mixed State of the aggregate
+     */
+    public function loadAggregateStateUntil(string $aggregateType, string $aggregateId, int $maxVersion);
 }

--- a/src/InnerEventStore.php
+++ b/src/InnerEventStore.php
@@ -41,11 +41,23 @@ trait InnerEventStore
      * @param string $aggregateType
      * @param string $aggregateId
      * @param int $minVersion
+     * @param int|null $maxVersion
      * @return \Iterator GenericEvent[]
      */
-    public function loadAggregateEvents(string $streamName, string $aggregateType, string $aggregateId, int $minVersion = 1): \Iterator
-    {
-        return $this->eventStore->loadAggregateEvents($streamName, $aggregateType, $aggregateId, $minVersion);
+    public function loadAggregateEvents(
+        string $streamName,
+        string $aggregateType,
+        string $aggregateId,
+        int $minVersion = 1,
+        int $maxVersion = null
+    ): \Iterator {
+        return $this->eventStore->loadAggregateEvents(
+            $streamName,
+            $aggregateType,
+            $aggregateId,
+            $minVersion,
+            $maxVersion
+        );
     }
 
     /**


### PR DESCRIPTION
**BC break**

Needs new version of [php-event-store](https://github.com/event-engine/php-event-store/pull/1/files).