### PR TITLE
Store indices in InMemoryConnection

### DIFF
--- a/src/InMemoryConnection.php
+++ b/src/InMemoryConnection.php
@@ -26,6 +26,7 @@ final class InMemoryConnection implements \ArrayAccess, TransactionalConnection
         'event_streams' => [],
         'projections' => [],
         'documents' => [],
+        'documentIndices' => [],
     ];
 
     /**


### PR DESCRIPTION
This is required by the InMemoryDocumentStore to support unique indices